### PR TITLE
More padding for Firefox on Windows

### DIFF
--- a/www/sass/_steps.scss
+++ b/www/sass/_steps.scss
@@ -44,7 +44,7 @@ div#whydio {
 #brand {
  text-transform: uppercase;
  letter-spacing: 1px;
- font-size: 10px; 
+ font-size: 10px;
  text-align: center;
  margin-bottom: 60px;
  img {
@@ -165,7 +165,7 @@ strong {
 }
 
 textarea#inputMessage {
-  padding-top: 40px;
+  padding-top: 42px;
   position: relative;
 }
 


### PR DESCRIPTION
I noticed a small UI issue with Firefox on Windows. The first line of the message gets cut off at the top. It's most noticeable with something like a capital 'T'.

![before](https://cloud.githubusercontent.com/assets/1216762/8731448/42da73c4-2bac-11e5-86bb-1e1070f873da.png)


After adding 2px of padding-top to the input message, the issue seems to be fixed.

![after](https://cloud.githubusercontent.com/assets/1216762/8731450/446dc380-2bac-11e5-9948-13f3171ecaa6.png)


I also removed an extra space at the end of line 47. Should help the `gulp css` task run more efficiently. :wink: 