### PR TITLE
Fixes a bug that currently causes almost no messages to send

### DIFF
--- a/server/swagger/models/message-sender.json
+++ b/server/swagger/models/message-sender.json
@@ -5,10 +5,9 @@
       "type": "string",
       "description": "The name prefix, e.g. Ms.",
       "enum": [
-        "Ms",
-        "Mr",
-        "Mrs",
-        "Dr"
+        "Ms.",
+        "Mr.",
+        "Mrs."
       ]
     },
     "firstName": {

--- a/www/js/helpers/message-form.js
+++ b/www/js/helpers/message-form.js
@@ -211,7 +211,7 @@ var createFormFields = function(legislatorsFormElements, legislators, address) {
   return {
     countyData: countyData,
     formData: {
-      prefix: 'Ms',
+      prefix: 'Ms.',
       county: countyData.selected
     },
     topicOptions: getTopicOptions(legislatorsFormElements, legislators)

--- a/www/partials/message-form.html
+++ b/www/partials/message-form.html
@@ -107,10 +107,9 @@
                       ng-required="true"
                       ng-focus="prefixFocus = true"
                       ng-blur="prefixFocus = false">
-                <option value="Mr">Mr</option>
-                <option value="Mrs">Mrs</option>
-                <option value="Ms">Ms</option>
-                <option value="Dr">Dr</option>
+                <option value="Mr.">Mr.</option>
+                <option value="Mrs.">Mrs.</option>
+                <option value="Ms.">Ms.</option>
               </select>
             </div>
             <div class="col-sm-6 form-group" ng-class="{'has-error' : (!messageForm.phone.$valid && !messageForm.phone.$pristine)}">


### PR DESCRIPTION
Fixes a bug caused by prefix fields labeled eg. "Mr" instead of "Mr." since the POTC API silently returns an "error" in its response object (still a 200), despite it appearing as though the message was sent successfully and advance to the Thanks page.

This isn't a complete fix (ideally we would import prefix form data from POTC as they vary across different forms), but it will enable most of the forms to work for now, instead of most of them not working.