### PR TITLE
Add empty alt tag to presentational image

### DIFF
--- a/server/templates/components/home-bottom.dust
+++ b/server/templates/components/home-bottom.dust
@@ -4,7 +4,7 @@
       <div id="video-container" class="col-sm-12 col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
         <h2>Why we built Democracy.io</h2>
         <div>
-          <img class="img-responsive" src="/static/{CONFIG.VERSION}/img/browser-header.png" >
+          <img class="img-responsive" src="/static/{CONFIG.VERSION}/img/browser-header.png" alt="" >
           <video id="video" in-view="autoplayVideo($event,$inview,$inviewpart)" controls width="100%">
             <source src="https://d1cv406lx4hgxd.cloudfront.net/dio-1.2.1c.mp4">
             Your browser does not support HTML5 video.


### PR DESCRIPTION
Saw you all discussing an accessibility audit in #13. One thing that stood out to me is that the browser header image doesn't have an alt tag causing screen readers to read the file name out loud.

Since it's only presentational, we could just add an empty alt tag so screen readers skip reading over it!
