### PR TITLE
Fix legislator lookup when district has no senator

### DIFF
--- a/server/routes/api/legislators/find-by-district.js
+++ b/server/routes/api/legislators/find-by-district.js
@@ -13,7 +13,7 @@ var get = function (req, res) {
   if (!Congress.validDistrict(state, district))
     res.status(400).json(resHelpers.makeError({ message: "Bad value for state/district parameter" }));
   else
-    res.json(resHelpers.makeResponse([Congress.House[state][district]].concat(Congress.Senate[state])));
+    res.json(resHelpers.makeResponse(Congress.getLegislators(state, district)));
 };
 
 

--- a/server/services/congress.js
+++ b/server/services/congress.js
@@ -14,7 +14,7 @@ var Congress = {
   getLegislators: function(state, district) {
     var reps = Congress.House[state][district];
     var senators = Congress.Senate[state];
-    return senators ? reps.concat(senators) : reps;
+    return senators ? [reps].concat(senators) : [reps];
   }
 };
 

--- a/server/services/congress.js
+++ b/server/services/congress.js
@@ -12,9 +12,9 @@ var Congress = {
   },
 
   getLegislators: function(state, district) {
-    var reps = Congress.House[state][district];
+    var rep = Congress.House[state][district];
     var senators = Congress.Senate[state];
-    return senators ? [reps].concat(senators) : [reps];
+    return senators ? [rep].concat(senators) : [rep];
   }
 };
 

--- a/server/services/congress.js
+++ b/server/services/congress.js
@@ -9,6 +9,12 @@ var Congress = {
 
   validDistrict: function(state, district) {
     return Congress.House[state] != undefined && Congress.House[state][district] != undefined;
+  },
+
+  getLegislators: function(state, district) {
+    var reps = Congress.House[state][district];
+    var senators = Congress.Senate[state];
+    return senators ? reps.concat(senators) : reps;
   }
 };
 


### PR DESCRIPTION
Some districts have a representative in the House but not in the Senate (Washington DC, US territories). This branch fixes rep lookup for that case.