### PR TITLE
Don't call res.send twice

### DIFF
--- a/server/routes/api/captcha-solution.js
+++ b/server/routes/api/captcha-solution.js
@@ -12,9 +12,8 @@ var post = function (req, res) {
   var solution = apiHelpers.getModelData(req.body, models.CaptchaSolution);
 
   potc.solveCaptcha(solution, req.app.locals.CONFIG, function(err, data) {
-    if (err) {
-      res.status(400).json(resHelpers.makeError(err));
-    }
+    if (err)
+      return res.status(400).json(resHelpers.makeError(err));
 
     // This kicks back a {'status': $status} response. There's no real point making an object.
     res.json(resHelpers.makeResponse(data));

--- a/server/routes/api/form-elements/find-by-legislator-bioguideIds.js
+++ b/server/routes/api/form-elements/find-by-legislator-bioguideIds.js
@@ -13,9 +13,8 @@ var get = function (req, res) {
   var bioguideIds = req.query.bioguideIds;
 
   potc.getFormElementsForRepIdsFromPOTC(bioguideIds, req.app.locals.CONFIG, function(err, data) {
-    if (err) {
-      res.status(400).json(resHelpers.makeError(err));
-    }
+    if (err)
+      return res.status(400).json(resHelpers.makeError(err));
 
     var modelData = lodash.reduce(data, function(results, val, bioguideId) {
       results.push(potcHelpers.makeLegislatorFormElements(val, bioguideId));

--- a/server/routes/api/legislator/{bioguideId}/form-elements.js
+++ b/server/routes/api/legislator/{bioguideId}/form-elements.js
@@ -13,9 +13,8 @@ var get = function (req, res) {
   var bioguideId = req.params.bioguideId;
 
   potc.getFormElementsForRepIdsFromPOTC([bioguideId], req.app.locals.CONFIG, function(err, data) {
-    if (err) {
-      res.status(400).json(resHelpers.makeError(err));
-    }
+    if (err)
+      return res.status(400).json(resHelpers.makeError(err));
 
     var modelData = potcHelpers.makeLegislatorFormElements(data[bioguideId], bioguideId);
     res.json(resHelpers.makeResponse(modelData));

--- a/server/routes/api/legislator/{bioguideId}/message.js
+++ b/server/routes/api/legislator/{bioguideId}/message.js
@@ -21,9 +21,8 @@ var post = function (req, res) {
   }
 
   potc.sendMessage(potcMessage, req.app.locals.CONFIG, function(err, data) {
-    if (err) {
-      res.status(400).json(resHelpers.makeError(err));
-    }
+    if (err)
+      return res.status(400).json(resHelpers.makeError(err));
 
     data.bioguideId = message.bioguideId;
     res.json(resHelpers.makeResponse(new models.MessageResponse(data)));

--- a/server/routes/api/location/verify.js
+++ b/server/routes/api/location/verify.js
@@ -17,9 +17,8 @@ var get = function (req, res) {
   //       So, just supply the full address returned from the API call.
   var params = {street: req.query.address};
   smartyStreets.verifyAddress(params, req.app.locals.CONFIG, function(err, data) {
-    if (err) {
-      res.status(400).json(resHelpers.makeError(err));
-    }
+    if (err)
+      return res.status(400).json(resHelpers.makeError(err));
 
     var canonicalAddresses = map(data, ssHelpers.makeCanonicalAddressFromSSResponse);
     res.json(resHelpers.makeResponse(canonicalAddresses));

--- a/server/routes/api/subscription.js
+++ b/server/routes/api/subscription.js
@@ -30,9 +30,8 @@ var post = function (req, res) {
   };
 
   effCivicCRM.subscribeToEFFMailingList(params, req.app.locals.CONFIG, function(err) {
-    if (err) {
-      res.status(400).json(resHelpers.makeError(err));
-    }
+    if (err)
+      return res.status(400).json(resHelpers.makeError(err));
 
     // TODO(leah): Look at the format of the response on this
     var modelData = {};


### PR DESCRIPTION
This branch prevents `res.json(...)` from being called in cases where `res.status(400).json(...)` has already been called. Since `res.json` actually sends back the HTTP response, calling it twice is an error.